### PR TITLE
Add index route to init

### DIFF
--- a/sandman_web/sandman_web/__init__.py
+++ b/sandman_web/sandman_web/__init__.py
@@ -26,10 +26,10 @@ def create_app(test_config = None):
     except OSError:
         pass
 
-    # A simple page that says hello.
-    @app.route('/hello')
-    def hello():
-        return 'Hello, World!'
+    # Sandman Reports Home Page
+    @app.route('/')
+    def home():
+        return reports.index()
 
     from . import reports
     app.register_blueprint(reports.blueprint)


### PR DESCRIPTION
Remove the unnecessary "hello" route and add the index route. This allows you to visit the root and not get a 404 error. 