### PR TITLE
Reports version 3.

### DIFF
--- a/sandman/data/sandman.sched
+++ b/sandman/data/sandman.sched
@@ -2,56 +2,18 @@
 <Schedule>
 	
 	<!-- At the moment, the events must be listed in sequence. -->
-	<Event>				
+	<!-- <Event> -->
 				
 		<!-- The delay after the previous schedule event before this one occurs. -->
-		<DelaySec>1800</DelaySec>
+		<!-- <DelaySec>1800</DelaySec> -->
 		<!-- The control action to trigger for the event. -->
-		<ControlAction>
+		<!-- <ControlAction> -->
 					
 			<!-- The name of the control to manipulate. -->
-			<ControlName>legs</ControlName>
+			<!-- <ControlName>legs</ControlName> -->
 			<!-- The action to perform on the control. -->
-			<Action>down</Action>					
-		</ControlAction>
-	</Event>
-	<Event>				
-				
-		<!-- The delay after the previous schedule event before this one occurs. -->
-		<DelaySec>2</DelaySec>
-		<!-- The control action to trigger for the event. -->
-		<ControlAction>
-					
-			<!-- The name of the control to manipulate. -->
-			<ControlName>back</ControlName>
-			<!-- The action to perform on the control. -->
-			<Action>up</Action>					
-		</ControlAction>
-	</Event>
-	<Event>				
-				
-		<!-- The delay after the previous schedule event before this one occurs. -->
-		<DelaySec>2700</DelaySec>
-		<!-- The control action to trigger for the event. -->
-		<ControlAction>
-					
-			<!-- The name of the control to manipulate. -->
-			<ControlName>back</ControlName>
-			<!-- The action to perform on the control. -->
-			<Action>down</Action>					
-		</ControlAction>
-	</Event>
-	<Event>				
-				
-		<!-- The delay after the previous schedule event before this one occurs. -->
-		<DelaySec>2</DelaySec>
-		<!-- The control action to trigger for the event. -->
-		<ControlAction>
-					
-			<!-- The name of the control to manipulate. -->
-			<ControlName>legs</ControlName>
-			<!-- The action to perform on the control. -->
-			<Action>up</Action>					
-		</ControlAction>
-	</Event>
+			<!-- <Action>down</Action>	-->
+		<!-- </ControlAction> -->
+	<!-- </Event> -->
+
 </Schedule>

--- a/sandman/source/command.cpp
+++ b/sandman/source/command.cpp
@@ -7,6 +7,7 @@
 #include "input.h"
 #include "logger.h"
 #include "notification.h"
+#include "reports.h"
 #include "schedule.h"
 
 #define DATADIR		AM_DATADIR
@@ -275,6 +276,8 @@ CommandParseTokensReturnTypes CommandParseTokens(char const*& p_ConfirmationText
 				
 				
 				l_Control->SetDesiredAction(l_Action, Control::MODE_TIMED, l_DurationPercent);
+
+				ReportsAddControlItem(l_Control->GetName(), l_Action, "command");
 				return CommandParseTokensReturnTypes::SUCCESS;
 			}
 			
@@ -282,6 +285,8 @@ CommandParseTokensReturnTypes CommandParseTokens(char const*& p_ConfirmationText
 			{
 				// Stop controls.
 				ControlsStopAll();			
+
+				ReportsAddControlItem("all", Control::ACTION_STOPPED, "command");
 				return CommandParseTokensReturnTypes::SUCCESS;
 			}
 			
@@ -324,6 +329,7 @@ CommandParseTokensReturnTypes CommandParseTokens(char const*& p_ConfirmationText
 					NotificationPlay("control_connected");
 				}
 
+				ReportsAddStatusItem();
 				return CommandParseTokensReturnTypes::SUCCESS;
 			}
 

--- a/sandman/source/control.cpp
+++ b/sandman/source/control.cpp
@@ -8,7 +8,6 @@
 
 #include "logger.h"
 #include "notification.h"
-#include "reports.h"
 #include "timer.h"
 #include "xml.h"
 
@@ -377,13 +376,6 @@ void Control::SetDesiredAction(Actions p_DesiredAction, Modes p_Mode,
 	LoggerAddMessage("Control \"%s\": Setting desired action to \"%s\" with mode \"%s\" and "
 		"duration %i ms.", m_Name, s_ControlActionNames[p_DesiredAction], 
 		s_ControlModeNames[p_Mode], m_MovingDurationMS);
-
-	// For now, only add an entry in the report if the mode is timed, because manual means it's 
-	// coming from a physical controller press.
-	if (m_Mode == MODE_TIMED)
-	{
-		ReportsAddItem("%s: %s", m_Name, s_ControlActionNames[m_DesiredAction]);
-	}
 }
 
 // Enable or disable all controls.

--- a/sandman/source/reports.h
+++ b/sandman/source/reports.h
@@ -1,6 +1,8 @@
 #pragma once
 
-#include <stdarg.h>
+#include <string.h>
+
+#include "control.h"
 
 // Types
 //
@@ -20,20 +22,21 @@ void ReportsUninitialize();
 //
 void ReportsProcess();
 
-// Add an item to the report.
-//
-// p_Format:	Standard printf format string.
-// ...:			Standard printf arguments.
-//
-// returns:		True if successful, false otherwise.
-//
-bool ReportsAddItem(char const* p_Format, ...);
+// Add an item to the report corresponding to a control event.
+// 
+// p_ControlName:	The name of the control.
+// p_Action:		The action performed on the control.
+// p_SourceName:	An identifier for where this item comes from.
+// 
+void ReportsAddControlItem(std::string const& p_ControlName, Control::Actions const p_Action, 
+	std::string const& p_SourceName);
 
-// Add an item to the report (va_list version).
-//
-// p_Format:		Standard printf format string.
-// p_Arguments:	Standard printf arguments.
-//
-// returns:		True if successful, false otherwise.
-//
-bool ReportsAddItem(char const* p_Format, va_list& p_Arguments);
+// Add an item to the report corresponding to a schedule event.
+// 
+// p_ActionName:	The name of the schedule action.
+// 
+void ReportsAddScheduleItem(std::string const& p_ActionName);
+
+// Add an item to the report corresponding to a status event.
+// 
+void ReportsAddStatusItem();

--- a/sandman/source/schedule.cpp
+++ b/sandman/source/schedule.cpp
@@ -10,6 +10,7 @@
 #include "control.h"
 #include "logger.h"
 #include "notification.h"
+#include "reports.h"
 #include "timer.h"
 #include "xml.h"
 
@@ -224,6 +225,9 @@ void ScheduleUninitialize()
 //
 void ScheduleStart()
 {
+	// Add the report item prior to checks, because we want to record the intent.
+	ReportsAddScheduleItem("start");
+
 	// Make sure it's initialized.
 	if (s_ScheduleInitialized == false)
 	{
@@ -249,6 +253,9 @@ void ScheduleStart()
 //
 void ScheduleStop()
 {
+	// Add the report item prior to checks, because we want to record the intent.
+	ReportsAddScheduleItem("stop");
+
 	// Make sure it's initialized.
 	if (s_ScheduleInitialized == false)
 	{
@@ -334,5 +341,7 @@ void ScheduleProcess()
 	// Perform the action.
 	l_Control->SetDesiredAction(l_Event.m_ControlAction.m_Action, Control::MODE_TIMED);
 	
+	ReportsAddControlItem(l_Control->GetName(), l_Event.m_ControlAction.m_Action, "schedule");
+
 	LoggerAddMessage("Schedule moving to event %i.", s_ScheduleIndex);
 }


### PR DESCRIPTION
* Replace the default schedule with an empty schedule.
* Change the formatting for report items to make the event into an object containing at the very least a type. In the case of control type events (which correspond to manipulating one of the controls), this adds the control action and a source specifier. The source specifier indicates whether the control event comes from a command or the schedule. This was not distinguished before. Also added report items for stopping all controls (which cannot be activated currently because it's not hooked up in the sentences), starting and stopping the schedule (schedule type) and checking the status. This also increases the report version.