### PR TITLE
Schedule updates.

### DIFF
--- a/sandman/data/example.sched
+++ b/sandman/data/example.sched
@@ -1,0 +1,19 @@
+{
+	"version" : 1,
+	"events" : [
+		{
+			"delaySec" : 20, 
+			"controlAction" : {
+				"control" : "legs",
+				"action" : "up"
+			}
+		}, 
+		{
+			"delaySec" : 25, 
+			"controlAction" : {
+				"control" : "legs",
+				"action" : "down"
+			}
+		}
+	]
+}

--- a/sandman/data/sandman.sched
+++ b/sandman/data/sandman.sched
@@ -1,19 +1,5 @@
-<?xml version="1.0"?>
-<Schedule>
-	
-	<!-- At the moment, the events must be listed in sequence. -->
-	<!-- <Event> -->
-				
-		<!-- The delay after the previous schedule event before this one occurs. -->
-		<!-- <DelaySec>1800</DelaySec> -->
-		<!-- The control action to trigger for the event. -->
-		<!-- <ControlAction> -->
-					
-			<!-- The name of the control to manipulate. -->
-			<!-- <ControlName>legs</ControlName> -->
-			<!-- The action to perform on the control. -->
-			<!-- <Action>down</Action>	-->
-		<!-- </ControlAction> -->
-	<!-- </Event> -->
-
-</Schedule>
+{
+	"version" : 1,
+	"events" : [
+	]
+}

--- a/sandman/source/control.h
+++ b/sandman/source/control.h
@@ -3,6 +3,7 @@
 #include <vector>
 
 #include <libxml/parser.h>
+#include "rapidjson/document.h"
 
 #include "timer.h"
 
@@ -214,6 +215,14 @@ struct ControlAction
 	//
 	bool ReadFromXML(xmlDocPtr p_Document, xmlNodePtr p_Node);
 	
+	// Read a control action from JSON. 
+	//
+	// p_Object:	The JSON object representing a control action.
+	//
+	// Returns:		True if the action was read successfully, false otherwise.
+	//
+	bool ReadFromJSON(rapidjson::Value::ConstObject const& p_Object);
+
 	// Attempt to get the control corresponding to the control action.
 	//
 	// Returns:	The control if successful, null otherwise.

--- a/sandman_web/sandman_web/reports.py
+++ b/sandman_web/sandman_web/reports.py
@@ -119,6 +119,23 @@ def report(year, month, day):
                 if line_event is None:
                     line_event = 'None'
 
+                if report_version == 2:
+                    # Convert the event into the most likely sort of control event.
+                    control_action_parts = line_event.split(': ')
+                    control_name = control_action_parts[0]
+
+                    control_action = 'stop'
+                    if control_action_parts[1] == 'moving up':
+                        control_action = 'move up'
+                    elif control_action_parts[1] == 'moving down':
+                        control_action = 'move down'
+
+                    line_event = {'type' : 'control',
+                                  'control' : control_name,
+                                  'action' : control_action, 
+                                  'source' : 'command'
+                                  }
+
                 report_infos.append((info_date_time, line_event))
 
         report_file.close()


### PR DESCRIPTION
* Converted the schedule from XML format to JSON. Because JSON does not include support for comments, adding an example file as a supplement to the default empty schedule. This may not be needed once we have support for specifying the schedule through the web interface. Also added a little bit nicer display of the loaded schedule in the case where the schedule is empty. Most importantly, fixed a crash bug if you started an empty schedule.

* Quick and dirty convert events from reports version 2 to the most likely version 3 format.