### PR TITLE
Fix static path used for reports style sheet

### DIFF
--- a/sandman_web/sandman_web/reports/reports.py
+++ b/sandman_web/sandman_web/reports/reports.py
@@ -17,7 +17,7 @@ report_extension = '.rpt'
 # The date and time format for report events.
 report_date_time_format = '%Y/%m/%d %H:%M:%S %Z'
 
-blueprint = Blueprint('reports', __name__, url_prefix = '/reports', template_folder='templates')
+blueprint = Blueprint('reports', __name__, url_prefix = '/reports', template_folder='templates', static_folder='static')
 
 @blueprint.route('/')
 def index():

--- a/sandman_web/sandman_web/reports/templates/report.html
+++ b/sandman_web/sandman_web/reports/templates/report.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block stylesheet %}
-  <link rel="stylesheet" href="{{ url_for('static', filename='report_style.css') }}">
+  <link rel="stylesheet" href="{{ url_for('.static', filename='report_style.css') }}">
 {% endblock %}
 
 {%- block header -%}


### PR DESCRIPTION
An issue was identified with the reports style sheet not loading most certainly due to the folder restructuring that I did a while back. This was resolved after reading this [article ](https://www.siparker.net/python/how-to-use-blueprint-static-folders-correctly-in-python-flask/)and learning how the static folder is treated differently than the template folder leading to these path issues.  