### PR TITLE
Rhasspy Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,20 +56,21 @@ You can solder wires from each relay directly to the pads of each hand control b
 
 ## Software Installation
 
-### Rhasspy
+### Repository Clone
 
-Sandman relies on [Rhasspy](https://rhasspy.readthedocs.io) to provide voice control and auditory feedback. Follow these [instructions](https://rhasspy.readthedocs.io/en/latest/installation/) in order to install Rhasspy on your Raspberry Pi. However, use the following command to start the Docker image rather than the one in the instructions, because we need to expose an additional port.
+You can download and extract the source or clone the repository using a command like this:
 
 ```bash
-docker run -d -p 12101:12101 -p 12183:12183 \
-      --name rhasspy \
-      --restart unless-stopped \
-      -v "$HOME/.config/rhasspy/profiles:/profiles" \
-      -v "/etc/localtime:/etc/localtime:ro" \
-      --device /dev/snd:/dev/snd \
-      rhasspy/rhasspy \
-      --user-profiles /profiles \
-      --profile en
+git clone https://github.com/shawn-lindberg/sandman.git
+```
+
+### Rhasspy
+
+Sandman relies on [Rhasspy](https://rhasspy.readthedocs.io) to provide voice control and auditory feedback. Follow these [instructions](https://rhasspy.readthedocs.io/en/latest/installation/) in order to install Rhasspy on your Raspberry Pi. However, use the following commands to start the Docker image rather than the one in the instructions, because we need to expose an additional port.
+
+```bash
+cd ~/sandman/rhasspy
+docker compose up -d
 ```
 
 Once Rhasspy is running, it can be configured through its web interface by going to YOUR_SANDMAN_IP_ADDRESS:12101. 
@@ -131,12 +132,6 @@ Currently, building Sandman from source requires the following libraries:
 
 ```bash
 sudo apt install bison autoconf automake libtool libncurses-dev libxml2-dev libmosquitto-dev -y
-```
-
-You can download and extract the source or clone the repository using a command like this:
-
-```bash
-git clone https://github.com/shawn-lindberg/sandman.git
 ```
 
 Then, it can be built and installed with the following commands:

--- a/rhasspy/docker-compose.yml
+++ b/rhasspy/docker-compose.yml
@@ -8,6 +8,7 @@ services:
         - "/etc/localtime:/etc/localtime:ro"
     ports:
         - "12101:12101"
+        - "12183:12183"
     devices:
         - "/dev/snd:/dev/snd"
     command: --user-profiles /profiles --profile en

--- a/rhasspy/docker-compose.yml
+++ b/rhasspy/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  rhasspy:
+    image: "rhasspy/rhasspy"
+    container_name: rhasspy
+    restart: unless-stopped
+    volumes:
+        - "$HOME/.config/rhasspy/profiles:/profiles"
+        - "/etc/localtime:/etc/localtime:ro"
+    ports:
+        - "12101:12101"
+    devices:
+        - "/dev/snd:/dev/snd"
+    command: --user-profiles /profiles --profile en
+    networks:
+      - sandman_network
+      
+networks:
+  sandman_network:
+    name: sandman_network


### PR DESCRIPTION
Add the necessary Docker compose file for creating Rhasspy instead of creating the container with a docker run command. Utilizing the docker compose file is important as it defines a Docker network utilized by Rhasspy and Sandman Web so that Sandman Web can better communicate with the Rhasspy container. 