### PR TITLE
Configure Tab Size for GitHub Website View of Repository

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,6 @@
 root = true
 
 # Use tab indentation with size 3.
-# See `./CODING-STANDARDS.md#tabs-versus-spaces`.
 [**]
 indent_style = tab
 indent_size = 3

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+# tab indentation with size 3
+# `./CODING-STANDARDS.md#tabs-versus-spaces`
+[**]
+indent_style = tab
+indent_size = 3

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 root = true
 
-# tab indentation with size 3
-# `./CODING-STANDARDS.md#tabs-versus-spaces`
+# Use tab indentation with size 3.
+# See `./CODING-STANDARDS.md#tabs-versus-spaces`.
 [**]
 indent_style = tab
 indent_size = 3

--- a/CODING-STANDARDS.md
+++ b/CODING-STANDARDS.md
@@ -85,13 +85,13 @@ if (l_Done == true)
 Regarding spaces, binary and tertiary operators should always have spaces between them like this:
 
 ```cpp
-l_Score = l_Multiplier * (l_Points + l_Bonus);
+int l_Score = l_Multiplier * (l_Points + l_Bonus);
 ```
 
 Unary operators should not have spaces.
 
 ```cpp
-l_Negative = -l_Positive;
+int l_Negative = -l_Positive;
 ```
 
 Pointer and reference specifiers go with the type, not the variable. They also shouldn't float:

--- a/CODING-STANDARDS.md
+++ b/CODING-STANDARDS.md
@@ -39,7 +39,7 @@ constexpr int MY_INTEGER_CONSTANT = 0;
 
 enum MyEnum
 {
-	MY_VALUE
+   MY_VALUE
 };
 ```
 
@@ -72,14 +72,14 @@ Braces should always go on their own line.
 ```cpp
 if (l_Done == true)
 {
-	// Do stuff.
+   // Do stuff.
 }
 ```
 No omission of braces.
 
 ```cpp
 if (l_Done == true)
-	s_Exit = true; // Wrong.
+   s_Exit = true; // Wrong.
 ```
 
 Regarding spaces, binary and tertiary operators should always have spaces between them like this:
@@ -120,11 +120,11 @@ Wrap after operators, not before.
 ```cpp
 // Right.
 float const l_Average = l_Total /
-								l_Count;
+                        l_Count;
 
 // Wrong.
 float const l_Average = l_Total
-								/ l_Count;
+                        / l_Count;
 ```
 
 Try to fit as many function arguments on each line as possible.
@@ -132,12 +132,12 @@ Try to fit as many function arguments on each line as possible.
 ```cpp
 // Right.
 void MyExtremelySuperDuperLongFunctionNameWithArguments(float p_Argument1, float p_Argument2,
-																		  float p_Argument3);
+                                                        float p_Argument3);
 
 // Wrong.
 void MyExtremelySuperDuperLongFunctionNameWithArguments(float p_Argument1,
-																		  float p_Argument2,
-																		  float p_Argument3);
+                                                        float p_Argument2,
+                                                        float p_Argument3);
 ```
 
 Also please notice that the wrapped lines are aligned.
@@ -146,5 +146,5 @@ String literals that are too long to fit on a line should be separated like foll
 
 ```cpp
 static char const* s_String = "This is a very long and descriptive string which has no other "
-										"purpose than to demonstrate how to wrap a string literal.";
+                              "purpose than to demonstrate how to wrap a string literal.";
 ```

--- a/CODING-STANDARDS.md
+++ b/CODING-STANDARDS.md
@@ -102,7 +102,7 @@ MyClass *l_MyPointer = nullptr; // Wrong.
 MyClass * l_MyPointer = nullptr; // Wrong.
 ```
 
-const should always be to the right of the thing that is constant.
+`const` should always be to the right of the thing that is constant.
 
 ```cpp
 // Both the characters and the pointer are constant.

--- a/CODING-STANDARDS.md
+++ b/CODING-STANDARDS.md
@@ -1,13 +1,3 @@
-<style>
-	/*
-		Set the tab size for code blocks to 3.
-      See `./CODING-STANDARDS.md#tabs-versus-spaces`.
-	*/
-	pre code {
-		tab-size: 3;
-	}
-</style>
-
 # Coding Standards
 
 What follows is intended to document as clearly as possible the coding standards used by the Sandman project. As Sandman is comprised of multiple programming languages, there will be a section dedicated to each. However, there may be cases where a particular point may not be clear. In that case, please consult with the project leader.

--- a/CODING-STANDARDS.md
+++ b/CODING-STANDARDS.md
@@ -18,7 +18,7 @@ Always use tabs instead of spaces. The tab width is three characters.
 
 Class and function names should follow this style:
 
-```
+```cpp
 class EveryWordCapitalized
 {
 };
@@ -32,7 +32,7 @@ bool MyJSONFunction();
 
 Constants and enumeration values should follow this style:
 
-```
+```cpp
 #define EVERY_WORD_CAPITALIZED_WITH_UNDERSCORES_BETWEEN
 
 constexpr int MY_INTEGER_CONSTANT = 0;
@@ -45,7 +45,7 @@ enum MyEnum
 
 Variables generally follow the same style as classes and functions, but always have a prefix:
 
-```
+```cpp
 // Global.
 float g_MyGlobalVariable = 0.0f;
 
@@ -69,7 +69,7 @@ bool l_ShouldContinue = false;
 
 Braces should always go on their own line. 
 
-```
+```cpp
 if (l_Done == true)
 {
 	// Do stuff.
@@ -77,26 +77,26 @@ if (l_Done == true)
 ```
 No omission of braces.
 
-```
+```cpp
 if (l_Done == true)
 	s_Exit = true; // Wrong.
 ```
 
 Regarding spaces, binary and tertiary operators should always have spaces between them like this:
 
-```
+```cpp
 l_Score = l_Multiplier * (l_Points + l_Bonus);
 ```
 
 Unary operators should not have spaces.
 
-```
+```cpp
 l_Negative = -l_Positive;
 ```
 
 Pointer and reference specifiers go with the type, not the variable. They also shouldn't float:
 
-```
+```cpp
 MyClass* l_MyPointer = nullptr; // Right.
 MyClass *l_MyPointer = nullptr; // Wrong.
 MyClass * l_MyPointer = nullptr; // Wrong.
@@ -104,7 +104,7 @@ MyClass * l_MyPointer = nullptr; // Wrong.
 
 const should always be to the right of the thing that is constant.
 
-```
+```cpp
 // Both the characters and the pointer are constant.
 char const* const l_String = "Yep";
 
@@ -117,7 +117,7 @@ Because of the maximum column width, there will be times when a line is too long
 
 Wrap after operators, not before.
 
-```
+```cpp
 // Right.
 float const l_Average = l_Total / 
 								l_Count;
@@ -129,7 +129,7 @@ float const l_Average = l_Total
 
 Try to fit as many function arguments on each line as possible.
 
-```
+```cpp
 // Right.
 void MyExtremelySuperDuperLongFunctionNameWithArguments(float p_Argument1, float p_Argument2, 
 																		  float p_Argument3);
@@ -144,7 +144,7 @@ Also please notice that the wrapped lines are aligned.
 
 String literals that are too long to fit on a line should be separated like follows.
 
-```
+```cpp
 static char const* s_String = "This is a very long and descriptive string which has no other "
 										"purpose than to demonstrate how to wrap a string literal.";
 ```

--- a/CODING-STANDARDS.md
+++ b/CODING-STANDARDS.md
@@ -1,3 +1,13 @@
+<style>
+	/*
+		Set the tab size for code blocks to 3.
+      See `./CODING-STANDARDS.md#tabs-versus-spaces`.
+	*/
+	pre code {
+		tab-size: 3;
+	}
+</style>
+
 # Coding Standards
 
 What follows is intended to document as clearly as possible the coding standards used by the Sandman project. As Sandman is comprised of multiple programming languages, there will be a section dedicated to each. However, there may be cases where a particular point may not be clear. In that case, please consult with the project leader.

--- a/CODING-STANDARDS.md
+++ b/CODING-STANDARDS.md
@@ -67,7 +67,7 @@ bool l_ShouldContinue = false;
 
 ### Formatting
 
-Braces should always go on their own line. 
+Braces should always go on their own line.
 
 ```cpp
 if (l_Done == true)
@@ -119,7 +119,7 @@ Wrap after operators, not before.
 
 ```cpp
 // Right.
-float const l_Average = l_Total / 
+float const l_Average = l_Total /
 								l_Count;
 
 // Wrong.
@@ -131,12 +131,12 @@ Try to fit as many function arguments on each line as possible.
 
 ```cpp
 // Right.
-void MyExtremelySuperDuperLongFunctionNameWithArguments(float p_Argument1, float p_Argument2, 
+void MyExtremelySuperDuperLongFunctionNameWithArguments(float p_Argument1, float p_Argument2,
 																		  float p_Argument3);
 
 // Wrong.
-void MyExtremelySuperDuperLongFunctionNameWithArguments(float p_Argument1, 
-																		  float p_Argument2, 
+void MyExtremelySuperDuperLongFunctionNameWithArguments(float p_Argument1,
+																		  float p_Argument2,
 																		  float p_Argument3);
 ```
 

--- a/CODING-STANDARDS.md
+++ b/CODING-STANDARDS.md
@@ -4,7 +4,7 @@ What follows is intended to document as clearly as possible the coding standards
 
 ## C/C++
 
-For C and C++ code there is a .clang-format file which does match the coding standard to the extent that clang-format supports. However, there are aspects of the coding standard that clang-format does not cover, for example naming conventions.
+For C and C++ code there is a [`.clang-format` file](sandman/.clang-format) which does match the coding standard to the extent that clang-format supports. However, there are aspects of the coding standard that clang-format does not cover, for example naming conventions.
 
 ### Column Width
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+<style>
+	/*
+		Set the tab size for code blocks to 3.
+      See `./CODING-STANDARDS.md#tabs-versus-spaces`.
+	*/
+	pre code {
+		tab-size: 3;
+	}
+</style>
+
 # Sandman
 
 Sandman is a device that is intended to assist people, particularly those with disabilities, in using hospital style beds. Therefore, it is not just software, but a combination of both software and hardware. The software is primarily designed to enable controlling a bed by voice. However, work is also underway on providing analytics of usage through a web interface. The current method of controlling the bed will work with any motorized bed that uses a hand control.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,3 @@
-<style>
-	/*
-		Set the tab size for code blocks to 3.
-      See `./CODING-STANDARDS.md#tabs-versus-spaces`.
-	*/
-	pre code {
-		tab-size: 3;
-	}
-</style>
-
 # Sandman
 
 Sandman is a device that is intended to assist people, particularly those with disabilities, in using hospital style beds. Therefore, it is not just software, but a combination of both software and hardware. The software is primarily designed to enable controlling a bed by voice. However, work is also underway on providing analytics of usage through a web interface. The current method of controlling the bed will work with any motorized bed that uses a hand control.


### PR DESCRIPTION
# GitHub Browser View

As this repository is public, it is nice for the code to be formatted properly when viewing it through the GitHub website.

This pull request edits `CODING-STANDARDS.md`, and adds a `.editorconfig` file to the root of the project. These changes make the view on GitHub better.

## `CODING-STANDARDS.md`

> The coding standards state to use tabs of size 3 instead of spaces.

### Before

The `CODING-STANDARDS.md` contains example code blocks demonstrating proper and improper ways of formatting the code for this project. However, when viewed on GitHub, some examples do not show properly.

For example, in the "Wrapping" section, there is an example where the lines aren't properly aligned. This is because GitHub's Markdown preview uses tab size 8 instead of size 3.

![image](https://github.com/shawn-lindberg/sandman/assets/73155005/11b31686-237e-472d-9be1-3e311b26a825)

### After

Using EditorConfig doesn't seem to change the Markdown preview, and `style` tags can't be used to change the tab size because GitHub sanitizes HTML from the Markdown preview. So, the straightforward way to align the code blocks is to use spaces.

![image](https://github.com/shawn-lindberg/sandman/assets/73155005/cf257252-1147-405a-981a-05967ac38c84)

Using spaces to format the code blocks instead of tabs is a compromise, but I think it is more important that whomever is viewing the coding standards in the browser sees how the code should look.

C++ syntax highlighting has also been added to the code blocks.

## Tabs

### Before

When browsing the source code in GitHub, the code is not formatted properly. The code is written with the expectation that tabs are of size 3. However, GitHub defaults to viewing code with tabs of size 8.

In `command.cpp`, here's an example where this discrepancy in tab size affects the looks of the code:
![image](https://github.com/shawn-lindberg/sandman/assets/73155005/b8b7d71e-9fcd-4f51-9b83-028e11515063)

### After

By adding a [`.editerconfig`](https://editorconfig.org/#example-file) file to the root of the project which GitHub recognizes, we can configure GitHub to use tabs of size 3.
```editorconfig
# `.editorconfig` at the root of the project

root = true

# Use tab indentation with size 3.
[**]
indent_style = tab
indent_size = 3
```

![image](https://github.com/shawn-lindberg/sandman/assets/73155005/d43ae9b4-077c-4213-874d-310d0ada4d62)

Now, the code is properly aligned when viewed in the browser.