### PR TITLE
GitHub Actions | New GitHub Action | Build Executable

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ indent_style = tab
 indent_size = 3
 
 # YAML Ain't Markup Language
-[**.{yml,.yaml}]
+[**.{yml,yaml}]
 indent_style = space
 indent_size = 2
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 root = true
 
-# Use tab indentation with size 3.
+# Use tab indentation with size 3 by default.
 [**]
 indent_style = tab
 indent_size = 3

--- a/.editorconfig
+++ b/.editorconfig
@@ -4,3 +4,13 @@ root = true
 [**]
 indent_style = tab
 indent_size = 3
+
+# YAML Ain't Markup Language
+[**.{yml,.yaml}]
+indent_style = space
+indent_size = 2
+
+# Python
+[**.py]
+indent_style = space
+indent_size = 4

--- a/.github/workflows/cmake_build.yaml
+++ b/.github/workflows/cmake_build.yaml
@@ -1,7 +1,11 @@
 name: CMake Build
 run-name: Build Sandman
 
-on: [push, pull_request, workflow_dispatch]
+on: 
+   push:
+      paths: ['sandman/**']
+   pull_request:
+   workflow_dispatch:
 
 jobs:
   build_Sandman_executable:

--- a/.github/workflows/cmake_build.yaml
+++ b/.github/workflows/cmake_build.yaml
@@ -2,16 +2,21 @@ name: CMake Build
 run-name: Build Sandman
 
 on:
+
   push:
+    branches: ["master"]
     paths: ['sandman/**']
+
   pull_request:
+
+  # Can run through GitHub user interface.
   workflow_dispatch:
 
 jobs:
   build_Sandman_executable:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4
 
       - name: Install NCurses

--- a/.github/workflows/cmake_build.yaml
+++ b/.github/workflows/cmake_build.yaml
@@ -16,6 +16,9 @@ jobs:
       - name: Install Mosquitto
         run: sudo apt-get install --yes libmosquitto-dev
 
+      - name: Install the Pi General Purpose Input Outputs C Library
+        run: sudo apt-get install --yes pigpio
+
       - name: Install CMake
         run: sudo apt-get install --yes cmake
 

--- a/.github/workflows/cmake_build.yaml
+++ b/.github/workflows/cmake_build.yaml
@@ -1,0 +1,17 @@
+name: CMake Build
+run-name: Build and lint Sandman.
+
+on: [push, pull_request]
+
+jobs:
+  build_Sandman_executable:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install CMake
+        run: sudo apt-get install cmake
+
+      - name: Build Sandman with CMake
+        run: cmake --build sandman/build

--- a/.github/workflows/cmake_build.yaml
+++ b/.github/workflows/cmake_build.yaml
@@ -1,7 +1,7 @@
 name: CMake Build
 run-name: Build Sandman
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build_Sandman_executable:

--- a/.github/workflows/cmake_build.yaml
+++ b/.github/workflows/cmake_build.yaml
@@ -1,5 +1,5 @@
 name: CMake Build
-run-name: Build and lint Sandman.
+run-name: Build Sandman
 
 on: [push, pull_request]
 
@@ -13,13 +13,13 @@ jobs:
       - name: Install NCurses
         run: sudo apt-get install --yes libncurses-dev
 
-      - name: Install Mosquitto
+      - name: Install Mosquitto MQTT Broker
         run: sudo apt-get install --yes libmosquitto-dev
 
       - name: Install CMake
         run: sudo apt-get install --yes cmake
 
-      - name: Generate CMake build files
+      - name: Generate CMake Build Files
         run: cmake -S sandman -B sandman/build -DENABLE_GPIO=OFF
 
       - name: Build Sandman with CMake

--- a/.github/workflows/cmake_build.yaml
+++ b/.github/workflows/cmake_build.yaml
@@ -1,11 +1,11 @@
 name: CMake Build
 run-name: Build Sandman
 
-on: 
-   push:
-      paths: ['sandman/**']
-   pull_request:
-   workflow_dispatch:
+on:
+  push:
+    paths: ['sandman/**']
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   build_Sandman_executable:

--- a/.github/workflows/cmake_build.yaml
+++ b/.github/workflows/cmake_build.yaml
@@ -1,4 +1,4 @@
-name: CMake Build
+name: Build Sandman Executable (without `pigpio.h`)
 run-name: Build Sandman
 
 on:

--- a/.github/workflows/cmake_build.yaml
+++ b/.github/workflows/cmake_build.yaml
@@ -5,7 +5,7 @@ on:
 
   push:
     branches: ["master"]
-    paths: ['sandman/**']
+    paths: ["sandman/**"]
 
   pull_request:
 

--- a/.github/workflows/cmake_build.yaml
+++ b/.github/workflows/cmake_build.yaml
@@ -13,5 +13,14 @@ jobs:
       - name: Install CMake
         run: sudo apt-get install cmake
 
+      - name: Echo Working Directory
+        run: echo "Working Directory is $GITHUB_WORKSPACE"
+
+      - name: check surroundings
+        run: ls -a
+
+      - name: Generate CMake build files
+        run: cmake -S sandman -B sandman/build
+
       - name: Build Sandman with CMake
         run: cmake --build sandman/build

--- a/.github/workflows/cmake_build.yaml
+++ b/.github/workflows/cmake_build.yaml
@@ -16,14 +16,11 @@ jobs:
       - name: Install Mosquitto
         run: sudo apt-get install --yes libmosquitto-dev
 
-      - name: Install the Pi General Purpose Input Outputs C Library
-        run: sudo apt-get install --yes pigpio
-
       - name: Install CMake
         run: sudo apt-get install --yes cmake
 
       - name: Generate CMake build files
-        run: cmake -S sandman -B sandman/build
+        run: cmake -S sandman -B sandman/build -DENABLE_GPIO=OFF
 
       - name: Build Sandman with CMake
         run: cmake --build sandman/build

--- a/.github/workflows/cmake_build.yaml
+++ b/.github/workflows/cmake_build.yaml
@@ -10,14 +10,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install NCurses
+        run: sudo apt-get install --yes libncurses-dev
+
+      - name: Install Mosquitto
+        run: sudo apt-get install --yes libmosquitto-dev
+
       - name: Install CMake
-        run: sudo apt-get install cmake
-
-      - name: Echo Working Directory
-        run: echo "Working Directory is $GITHUB_WORKSPACE"
-
-      - name: check surroundings
-        run: ls -a
+        run: sudo apt-get install --yes cmake
 
       - name: Generate CMake build files
         run: cmake -S sandman -B sandman/build


### PR DESCRIPTION
Created a GitHub action that builds Sandman with CMake.

Note, it compiles with `-DENABLE_GPIO=OFF`.

When does this action run:

* On pushes to `master` branch when changes have been made inside the `sandman` directory (the sub-directory, not the root).
* On Pull Requests
* Through the user interface on GitHub

I also updated `.editorconfig`.