### PR TITLE
GitHub Actions | New GitHub Action | Build Documentation and Deploy to GitHub Pages

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -38,6 +38,9 @@ jobs:
       - name: Install CMake
         run: sudo apt-get install --yes cmake
 
+      - name: Install Doxygen
+        run: sudo apt-get install --yes doxygen
+
       - name: Generate CMake Build Files
         run: cmake -S sandman -Bsandman/build -DDOXYGEN_OUTPUT_DIRECTORY=website -DDOXYGEN_HTML_OUTPUT=documentation
 

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -4,7 +4,7 @@ run-name: Build and Deploy Documentation to GitHub Pages
 
 on:
   push:
-    # branches: ["master"]
+    branches: ["master"]
     paths: ["sandman/**"]
 
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -1,5 +1,6 @@
 # Simple workflow for deploying static content to GitHub Pages
-name: Deploy static content to Pages
+name: Build and Deploy Documentation
+run-name: Deploy Documentation to Website
 
 on:
   push:

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -1,6 +1,6 @@
 # Simple workflow for deploying static content to GitHub Pages
-name: Deploy Documentation to Website
-run-name: Build and Deploy Documentation to GitHub Pages
+name: Build and Deploy Documentation to GitHub Pages
+run-name: Deploy Documentation To Website
 
 on:
   push:

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -48,7 +48,7 @@ jobs:
         run: cmake -S sandman -Bsandman/build -DDOXYGEN_OUTPUT_DIRECTORY=website -DDOXYGEN_HTML_OUTPUT=documentation
 
       - name: Build Documentation with CMake and Doxygen
-        run: cmake --build sandman/build
+        run: cmake --build sandman/build/ --target=documentation
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -35,6 +35,9 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
+      - name: Install Mosquitto MQTT Broker (Unused)
+        run: sudo apt-get install --yes libmosquitto-dev
+
       - name: Install CMake
         run: sudo apt-get install --yes cmake
 

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -1,0 +1,53 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  push:
+    # branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Install CMake
+        run: sudo apt-get install --yes cmake
+
+      - name: Generate CMake Build Files
+        run: cmake -S sandman -Bsandman/build -DDOXYGEN_OUTPUT_DIRECTORY=website -DDOXYGEN_HTML_OUTPUT=documentation
+
+      - name: Build Documentation with CMake and Doxygen
+        run: cmake --build sandman/build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './sandman/build/website/'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -1,10 +1,11 @@
 # Simple workflow for deploying static content to GitHub Pages
-name: Build and Deploy Documentation
-run-name: Deploy Documentation to Website
+name: Deploy Documentation to Website
+run-name: Build and Deploy Documentation to GitHub Pages
 
 on:
   push:
     # branches: ["master"]
+    paths: ["sandman/**"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/sandman/CMakeLists.txt
+++ b/sandman/CMakeLists.txt
@@ -3,3 +3,33 @@ project(Sandman)
 
 add_subdirectory(source)
 add_subdirectory(data)
+
+find_package(Doxygen)
+if(DOXYGEN_FOUND)
+	message(STATUS "Doxygen found: `${DOXYGEN_EXECUTABLE}` version ${DOXYGEN_VERSION}")
+
+	# MESSAGE(
+	# 	STATUS
+	# 	"Source Directory: ${PROJECT_SOURCE_DIR}, Binary Directory: ${CMAKE_CURRENT_BINARY_DIR}, Other Source Directory: ${CMAKE_SOURCE_DIR}"
+	# )
+
+	set(DOXYGEN_PROJECT_NAME Sandman)
+	set(DOXYGEN_PROJECT_BRIEF "A device to allow people to control hospital style beds by voice.")
+	
+	set(DOXYGEN_EXCLUDE_PATTERNS ${PROJECT_SOURCE_DIR}/source/rapidjson/**)
+
+	set(DOXYGEN_GENERATE_HTML YES)
+	set(DOXYGEN_GENERATE_MAN NO)
+	set(DOXYGEN_GENERATE_LATEX NO)
+	set(DOXYGEN_GENERATE_XML NO)
+
+	doxygen_add_docs(
+		documentation
+		${PROJECT_SOURCE_DIR}/source
+		comment "Generating documentation with Doxygen."
+	)
+
+else()
+	message(WARNING "Doxygen not found. Documentation will not be generated.")
+endif()
+

--- a/sandman/CMakeLists.txt
+++ b/sandman/CMakeLists.txt
@@ -25,6 +25,6 @@ if(DOXYGEN_FOUND)
 	)
 
 else()
-	message(WARNING "Doxygen not found. Documentation will not be generated.")
+	message(WARNING "Documentation cannot be generated without Doxygen.")
 endif()
 

--- a/sandman/CMakeLists.txt
+++ b/sandman/CMakeLists.txt
@@ -10,6 +10,8 @@ if(DOXYGEN_FOUND)
 
 	set(DOXYGEN_PROJECT_NAME Sandman)
 	set(DOXYGEN_PROJECT_BRIEF "A device to allow people to control hospital style beds by voice.")
+
+	set(DOXYGEN_TAB_SIZE 3)
 	
 	set(DOXYGEN_EXCLUDE_PATTERNS ${PROJECT_SOURCE_DIR}/source/rapidjson/**)
 

--- a/sandman/CMakeLists.txt
+++ b/sandman/CMakeLists.txt
@@ -13,6 +13,7 @@ if(DOXYGEN_FOUND)
 
 	set(DOXYGEN_TAB_SIZE 3)
 	
+	# Do not include third-party libraries in documentation.
 	set(DOXYGEN_EXCLUDE_PATTERNS ${PROJECT_SOURCE_DIR}/source/rapidjson/**)
 
 	set(DOXYGEN_GENERATE_HTML YES)

--- a/sandman/CMakeLists.txt
+++ b/sandman/CMakeLists.txt
@@ -8,11 +8,6 @@ find_package(Doxygen)
 if(DOXYGEN_FOUND)
 	message(STATUS "Doxygen found: `${DOXYGEN_EXECUTABLE}` version ${DOXYGEN_VERSION}")
 
-	# MESSAGE(
-	# 	STATUS
-	# 	"Source Directory: ${PROJECT_SOURCE_DIR}, Binary Directory: ${CMAKE_CURRENT_BINARY_DIR}, Other Source Directory: ${CMAKE_SOURCE_DIR}"
-	# )
-
 	set(DOXYGEN_PROJECT_NAME Sandman)
 	set(DOXYGEN_PROJECT_BRIEF "A device to allow people to control hospital style beds by voice.")
 	

--- a/sandman/source/logger.h
+++ b/sandman/source/logger.h
@@ -29,8 +29,8 @@ void LoggerEchoToScreen(bool p_LogToScreen);
 
 /// @brief Add a message to the log.
 ///
-/// @param p_Format Standard printf format string.
-/// @param ... Standard printf arguments.
+/// @param p_Format Standard `printf` format string.
+/// @param ... Standard `printf` arguments.
 ///
 /// @returns `true` if successful, `false` otherwise.
 ///
@@ -38,8 +38,8 @@ bool LoggerAddMessage(char const* p_Format, ...);
 
 /// @brief Add a message to the log (`va_list` version).
 ///
-/// @param p_Format Standard printf format string.
-/// @param p_Arguments Standard printf arguments.
+/// @param p_Format Standard `printf` format string.
+/// @param p_Arguments Standard `printf` arguments.
 ///
 /// @returns `true` if successful, `false` otherwise.
 ///

--- a/sandman/source/logger.h
+++ b/sandman/source/logger.h
@@ -1,3 +1,4 @@
+/// @file
 #pragma once
 
 #include <stdarg.h>
@@ -8,39 +9,39 @@
 // Functions
 //
 
-// Initialize the logger.
-//
-// p_LogFileName:	File name of the log for output.
-//
-// returns:		True if successful, false otherwise.
-//
+/// @brief Initialize the logger.
+///
+/// @param p_LogFileName File name of the log for output.
+///
+/// @returns `true` if successful, `false` otherwise.
+///
 bool LoggerInitialize(char const* p_LogFileName);
 
-// Uninitialize the logger.
-//
+/// @brief Uninitialize the logger.
+///
 void LoggerUninitialize();
 
-// Set whether to echo messages to the screen as well.
-//
-// p_LogToScreen:	Whether to echo messages to the screen.
-//
+/// @brief Set whether to echo messages to the screen as well.
+///
+/// @param p_LogToScreen Whether to echo messages to the screen.
+///
 void LoggerEchoToScreen(bool p_LogToScreen);
 
-// Add a message to the log.
-//
-// p_Format:	Standard printf format string.
-// ...:			Standard printf arguments.
-//
-// returns:		True if successful, false otherwise.
-//
+/// @brief Add a message to the log.
+///
+/// @param p_Format Standard printf format string.
+/// @param ... Standard printf arguments.
+///
+/// @returns `true` if successful, `false` otherwise.
+///
 bool LoggerAddMessage(char const* p_Format, ...);
 
-// Add a message to the log (va_list version).
-//
-// p_Format:		Standard printf format string.
-// p_Arguments:	Standard printf arguments.
-//
-// returns:		True if successful, false otherwise.
-//
+/// @brief Add a message to the log (`va_list` version).
+///
+/// @param p_Format Standard printf format string.
+/// @param p_Arguments Standard printf arguments.
+///
+/// @returns `true` if successful, `false` otherwise.
+///
 bool LoggerAddMessage(char const* p_Format, va_list& p_Arguments);
 


### PR DESCRIPTION
# Build Documentation with Doxygen and Deploy to GitHub Pages

> [Doxygen](https://www.doxygen.nl/) is a tool that builds documentation from comments in source code.

This pull request adds Doxygen documentation as a target to the CMake configuration, and a workflow that can deploy the documentation to GitHub Pages.

Comments have to be formatted in a certain way for Doxygen to work. [Doxygen comments can start with `///`, or be Javadoc-style comments.](https://www.doxygen.nl/manual/docblocks.html)

I annotated `logger.h` with Doxygen-style comments as an example.
[You can see how the documentation looks for `logger.h`.](https://serene-meadow.github.io/sandman/documentation/logger_8h.html)

### CMake

A new target `documentation` was added that uses Doxygen to generate documentation. If Doxygen, isn't installed, a warning is printed and this target is unavailable.

### `website.yaml`

This action builds documentation and deploys it to a website. It runs when a push to `master` has made changes to files in the `sandman` directory (the sub-directory, not root).
