### PR TITLE
Fix Deadlock

### DIFF
--- a/sandman/source/shell.cpp
+++ b/sandman/source/shell.cpp
@@ -16,7 +16,7 @@
 
 namespace Shell
 {
-	static std::mutex s_Mutex;
+	static std::recursive_mutex s_Mutex;
 
 	Lock::Lock(): m_Lock(s_Mutex) {};
 

--- a/sandman/source/shell.h
+++ b/sandman/source/shell.h
@@ -26,10 +26,12 @@ namespace Shell
 {
 	using namespace std::string_view_literals;
 
+	// This lock is implemented using a recursive mutex,
+	// so multiple instances of this class can be created within the same thread.
 	class [[nodiscard]] Lock final
 	{
 		private:
-			std::lock_guard<std::mutex> m_Lock;
+			std::lock_guard<std::recursive_mutex> m_Lock;
 		public:
 			[[nodiscard]] explicit Lock();
 	};


### PR DESCRIPTION
There was an oversight in previous code that I wrote that causes a deadlock.

This pull request changes the lock for the shell state to use `std::recursive_mutex` instead of `std::mutex`; this avoids the deadlock.

Here is what I believe was happening:
1. `main()` locks the shell state before checking for user input.
2. The user has submitted a command.
3. The logger tries lock the shell state to log the command, resulting in deadlock.

By changing the lock to use a recursive mutex rather than a regular mutex, this allows function calls from the shell namespace that are protected by a lock guard to use the logger within the same thread without deadlock.