### PR TITLE
Shell improvement change follow-up items.

### DIFF
--- a/sandman/source/main.cpp
+++ b/sandman/source/main.cpp
@@ -195,7 +195,7 @@ static bool Initialize()
 	}
 
 	// Initialize controls.
-	static constexpr bool kEnableGPIO{ false };
+	static constexpr bool kEnableGPIO = true;
 	ControlsInitialize(config.GetControlConfigs(), kEnableGPIO);
 
 	// Set control durations.

--- a/sandman/source/shell.cpp
+++ b/sandman/source/shell.cpp
@@ -462,7 +462,11 @@ namespace Shell
 				CommandTokenizeString(commandTokens, s_Buffer.GetData().data());
 
 				// Parse command tokens.
-				CommandParseTokens(commandTokens);
+				if (CommandParseTokens(commandTokens) == CommandParseTokensReturnTypes::kInvalid)
+				{
+					LoggingWindow::PrintLine(Red("Invalid command: \""), s_Buffer.GetData().data(), 
+													 Red("\"."));
+				}
 			}
 
 			static std::unordered_map<std::string_view, bool (*)()> const s_DispatchTable


### PR DESCRIPTION
While looking into hang occurring with the interactive shell, I noticed that during initialization GPIO was accidentally getting disabled. This change fixes that.

I also thought it would be helpful to output some sort of error message when entering an invalid command in the interactive shell. Now it does that.