### PR TITLE
Remove control handles.

### DIFF
--- a/sandman/source/command.cpp
+++ b/sandman/source/command.cpp
@@ -58,11 +58,6 @@ static std::map<std::string, CommandToken::Types> const s_commandTokenNameToType
 	// "integer", 	kTypeInteger
 };
 
-// Keep handles to the controls.
-static ControlHandle s_backControlHandle;
-static ControlHandle s_legsControlHandle;
-static ControlHandle s_elevationControlHandle;
-
 // Keep a handle to the input.
 static Input const* s_input = nullptr;
 
@@ -182,37 +177,19 @@ CommandParseTokensReturnTypes CommandParseTokens(char const*& confirmationText,
 				{
 					case CommandToken::kTypeBack:
 					{
-						// Try to find the control.
-						if (s_backControlHandle.IsValid() == false)
-						{
-							s_backControlHandle = Control::GetHandle("back");
-						}
-						
-						control = Control::GetFromHandle(s_backControlHandle);
+						control = Control::GetByName("back");
 					}
 					break;
 					
 					case CommandToken::kTypeLegs:
-					{
-						// Try to find the control.
-						if (s_legsControlHandle.IsValid() == false)
-						{
-							s_legsControlHandle = Control::GetHandle("legs");
-						}
-						
-						control = Control::GetFromHandle(s_legsControlHandle);
+					{						
+						control = Control::GetByName("legs");
 					}
 					break;
 					
 					case CommandToken::kTypeElevation:
 					{
-						// Try to find the control.
-						if (s_elevationControlHandle.IsValid() == false)
-						{
-							s_elevationControlHandle = Control::GetHandle("elev");
-						}
-			
-						control = Control::GetFromHandle(s_elevationControlHandle);
+						control = Control::GetByName("elev");
 					}
 					break;
 					

--- a/sandman/source/control.cpp
+++ b/sandman/source/control.cpp
@@ -580,6 +580,8 @@ void ControlsInitialize(std::vector<ControlConfig> const& configs)
 //
 void ControlsUninitialize()
 {
+	s_controlNameToIndexMap.clear();
+	
 	for (auto& control : s_controls)
 	{
 		control.Uninitialize();

--- a/sandman/source/control.cpp
+++ b/sandman/source/control.cpp
@@ -2,6 +2,7 @@
 
 #include <cstdio>
 #include <cstring>
+#include <map>
 #include <vector>
 
 #include "gpio.h"
@@ -23,11 +24,8 @@
 // Time between commands.
 //#define COMMAND_INTERVAL_MS				(2 * 1000) // 2 sec.
 
-// Locals
-//
-
 // The names of the actions.
-static char const* const s_controlActionNames[] =
+static constexpr char const* const kControlActionNames[] =
 {
 	"stopped",		// kActionStopped
 	"moving up",	// kActionMovingUp
@@ -37,7 +35,7 @@ static char const* const s_controlActionNames[] =
 // The names of the modes.
 static constexpr char const* const kControlModeNames[] =
 {
-	"manual",		// kModeManual
+	"manual",	// kModeManual
 	"timed",		// kModeTimed
 };
 
@@ -59,8 +57,14 @@ static constexpr char const* const kControlStateNotificationNames[] =
 	"stop",			// kStateCoolDown
 };
 
+// Locals
+//
+
 // A list of registered controls.
 static std::vector<Control> s_controls;
+
+// A mapping of control name to control index.
+static std::map<std::string, unsigned int> s_controlNameToIndexMap;
 
 // Control members
 
@@ -70,12 +74,7 @@ unsigned int Control::ms_coolDownDurationMS = MAX_COOL_DOWN_STATE_DURATION_MS;
 // Functions
 //
 
-// ControlHandle members
-
-// A private constructor.
-ControlHandle::ControlHandle(unsigned short uID) : m_uID(uID)
-{
-}
+// ControlConfig members
 
 // Read a control config from JSON. 
 //
@@ -375,7 +374,7 @@ void Control::SetDesiredAction(Actions desiredAction, Modes mode, unsigned int d
 	}
 
 	Logger::WriteLine("Control \"", m_name, "\": Setting desired action to \"",
-							s_controlActionNames[desiredAction], "\" with mode \"",
+							kControlActionNames[desiredAction], "\" with mode \"",
 							kControlModeNames[mode], "\" and duration ", m_movingDurationMS, " ms.");
 }
 
@@ -409,58 +408,22 @@ void Control::SetDurations(unsigned int movingDurationMS, unsigned int coolDownD
 							coolDownDurationMS, " ms.");
 }
 
-// Attempt to get the handle of a control based on its name.
+// Look up a control by its name.
 //
-// name:	The unique name of the control.
+// name:	The name of the control.
 //
-// Returns:	A handle to the control, or an invalid handle if one with the given name could not be found.
+// Returns:		The control, or null if one with the name could not be found.
 //
-ControlHandle Control::GetHandle(char const* name)
+Control* Control::GetByName(std::string const& name)
 {
-	ControlHandle handle;
-	
-	auto const controlCount = static_cast<unsigned short>(s_controls.size());
-	for (unsigned short controlIndex = 0; controlIndex < controlCount; controlIndex++)
-	{
-		auto const& control = s_controls[controlIndex];
-		
-		// Look for a control with the matching name.
-		if (strcmp(control.GetName(), name) != 0)
-		{
-			continue;
-		}
-		
-		// Found it, return the handle.
-		handle.m_uID = controlIndex;
-		break;
-	}
-	
-	// Return the handle we found, or didn't.
-	return handle;
-}
-
-// Look up a control from its handle.
-//
-// handle:	A handle to the control.
-//
-// Returns:		The control, or null if the handle is not valid.
-//
-Control* Control::GetFromHandle(ControlHandle const& handle)
-{
-	// Sanity checking.
-	if (handle.IsValid() == false)
+	auto controlIterator = s_controlNameToIndexMap.find(name);
+	if (controlIterator == s_controlNameToIndexMap.end())
 	{
 		return nullptr;
 	}
 	
-	auto const controlCount = static_cast<unsigned short>(s_controls.size());
-	if (handle.m_uID >= controlCount)
-	{
-		return nullptr;
-	}
-	
-	// Seems we have a valid handle, return the control.
-	return &(s_controls[handle.m_uID]);
+	auto const controlIndex = controlIterator->second;
+	return &s_controls[controlIndex];
 }
 		
 // Play a notification for the state.
@@ -593,15 +556,9 @@ bool ControlAction::ReadFromJSON(rapidjson::Value const& object)
 //
 // Returns:	The control if successful, null otherwise.
 //
-Control* ControlAction::GetControl()
+Control* ControlAction::GetControl() const
 {
-	// Look up the handle, if we haven't done that yet.
-	if (m_controlHandle.IsValid() == false) {
-		m_controlHandle = Control::GetHandle(m_controlName);
-	}
-	
-	// Try to find the control.
-	return Control::GetFromHandle(m_controlHandle);
+	return Control::GetByName(m_controlName);
 }
 	
 // Functions
@@ -651,7 +608,7 @@ void ControlsProcess()
 bool ControlsCreateControl(ControlConfig const& config)
 {
 	// Check to see whether a control with this name already exists.
-	if (Control::GetHandle(config.m_name).IsValid() == true)
+	if (s_controlNameToIndexMap.find(config.m_name) != s_controlNameToIndexMap.end())
 	{
 		Logger::WriteLine("Control with name \"", config.m_name, "\" already exists.");
 		return false;
@@ -661,9 +618,12 @@ bool ControlsCreateControl(ControlConfig const& config)
 	s_controls.emplace_back(Control());
 	
 	// Then, initialize it.
-	auto& control = s_controls.back();
-	control.Initialize(config);
+	unsigned int const controlIndex = s_controls.size() - 1;
+	s_controls[controlIndex].Initialize(config);
 	
+	// And add it to the map.
+	s_controlNameToIndexMap.insert({config.m_name, controlIndex});
+
 	return true;
 }
 

--- a/sandman/source/control.h
+++ b/sandman/source/control.h
@@ -9,35 +9,6 @@
 // Types
 //
 
-// A handle to a control.
-class ControlHandle
-{
-	public:
-		
-		// Only allow non-friends to construct invalid handles.
-		ControlHandle() = default;
-		
-		// Determine whether the handle is valid.
-		//
-		bool IsValid() const
-		{
-			return (m_uID != kInvalidUID);
-		}
-				
-	private:
-	
-		// Make this constructor private so that non-friends can only construct invalid handles.
-		ControlHandle(unsigned short uID);
-		
-		friend class Control;
-		
-		// The invalid unique identifier for a control.
-		static constexpr unsigned short kInvalidUID{ 0xFFFF };
-		
-		// The unique identifier for the control.
-		unsigned short m_uID = kInvalidUID;
-};
-
 // Configuration parameters to initialize a control.
 struct ControlConfig
 {
@@ -144,26 +115,18 @@ class Control
 		//
 		static void SetDurations(unsigned int movingDurationMS, unsigned int coolDownDurationMS);
 		
-		// Attempt to get the handle of a control based on its name.
+		// Look up a control by its name.
 		//
-		// name:	The unique name of the control.
+		// name:	The name of the control.
 		//
-		// Returns:	A handle to the control, or an invalid handle if one with the given name could not be found.
+		// Returns:		The control, or null if one with the name could not be found.
 		//
-		static ControlHandle GetHandle(char const* name);
-
-		// Look up a control from its handle.
-		//
-		// handle:	A handle to the control.
-		//
-		// Returns:		The control, or null if the handle is not valid.
-		//
-		static Control* GetFromHandle(ControlHandle const& handle);
+		static Control* GetByName(std::string const& name);
 		
 	private:
 
 		// Constants.
-		static constexpr unsigned int kNameCapacity{ 32u };
+		static constexpr unsigned int kNameCapacity = 32u;
 
 		// Play a notification for the state.
 		//
@@ -222,19 +185,16 @@ struct ControlAction
 	//
 	// Returns:	The control if successful, null otherwise.
 	//
-	Control* GetControl();
+	Control* GetControl() const;
 	
 	// Constants.
-	static constexpr unsigned int kControlNameCapacity{ 32u };
+	static constexpr unsigned int kControlNameCapacity = 32u;
 	
 	// The name of the control to manipulate.
 	char m_controlName[kControlNameCapacity];
 	
 	// The action for the control.
 	Control::Actions m_action;
-	
-	// A handle to the control for fast lookup.
-	ControlHandle m_controlHandle;
 };
 
 

--- a/sandman/tests/tests.cpp
+++ b/sandman/tests/tests.cpp
@@ -169,33 +169,25 @@ TEST_CASE("Test controls", "[control]")
 
 		// Test an invalid control.
 		{
-			ControlHandle handle = Control::GetHandle("chicken");
-			REQUIRE(handle.IsValid() == false);
-			Control* control = Control::GetFromHandle(handle);
+			Control* control = Control::GetByName("chicken");
 			REQUIRE(control == nullptr);
 		}
 
-		ControlHandle legHandle = Control::GetHandle("legs");
-		REQUIRE(legHandle.IsValid() == true);
-		Control* legControl = Control::GetFromHandle(legHandle);
+		Control* legControl = Control::GetByName("legs");
 		REQUIRE(legControl != nullptr);
 		if (legControl != nullptr)
 		{
 			REQUIRE(legControl->GetState() == Control::kStateIdle);
 		}
 
-		ControlHandle backHandle = Control::GetHandle("back");
-		REQUIRE(backHandle.IsValid() == true);
-		Control* backControl = Control::GetFromHandle(backHandle);
+		Control* backControl = Control::GetByName("back");
 		REQUIRE(backControl != nullptr);
 		if (backControl != nullptr)
 		{
 			REQUIRE(backControl->GetState() == Control::kStateIdle);
 		}
 
-		ControlHandle elevationHandle = Control::GetHandle("elev");
-		REQUIRE(elevationHandle.IsValid() == true);
-		Control* elevationControl = Control::GetFromHandle(elevationHandle);
+		Control* elevationControl = Control::GetByName("elev");
 		REQUIRE(elevationControl != nullptr);
 		if (elevationControl != nullptr)
 		{


### PR DESCRIPTION
Replace control handles with a map look up based on name. This actually simplifies things and I can't imagine this being a performance bottleneck unless there ends up being a lot more controls in the future. It also avoids some awkwardness forcing the control actions to be non-const.