### PR TITLE
CMake Presets & Script Modifications

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,6 @@
 {
-	"files.readonlyInclude": {
-		"build/**": true
-	},
-	"editor.rulers": [
-		100
-	],
+	"files.readonlyInclude": {"build/**": true},
+	"editor.rulers": [100],
 	"cmake.sourceDirectory": "${workspaceFolder}/sandman",
 	"cmake.allowCommentsInPresetsFile": false,
 	"cmake.automaticReconfigure": false,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+	"files.readonlyInclude": {
+		"build/**": true
+	},
+	"editor.rulers": [
+		100
+	],
+	"cmake.sourceDirectory": "${workspaceFolder}/sandman",
+	"cmake.allowCommentsInPresetsFile": false,
+	"cmake.automaticReconfigure": false,
+	"cmake.configureOnEdit": false,
+	"cmake.useCMakePresets": "always",
+	"cmake.ignoreKitEnv": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,17 @@
 	"cmake.automaticReconfigure": false,
 	"cmake.configureOnEdit": false,
 	"cmake.useCMakePresets": "always",
-	"cmake.ignoreKitEnv": true
+	"cmake.ignoreKitEnv": true,
+	"cmake.debugConfig": {
+		"environment": [
+			/*
+				Don't use leak sanitizer while debugging with GDB.
+				Only one program can use `ptrace` at a time,
+				and both leak sanitizer and GDB want to use `ptrace`.
+			*/
+			{
+				"name": "LSAN_OPTIONS", "value": "detect_leaks=false"
+			}
+		]
+	}
 }

--- a/sandman/CMakePresets.json
+++ b/sandman/CMakePresets.json
@@ -1,0 +1,39 @@
+{
+	"version": 6,
+	"configurePresets": [
+		{
+			"name": "common", "hidden": true,
+			"binaryDir": "${sourceDir}/../build/${presetName}",
+			"cacheVariables": { "CMAKE_EXPORT_COMPILE_COMMANDS": "ON" },
+			"condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Linux" }
+		},
+		{ "name": "release", "hidden": true, "cacheVariables": { "CMAKE_BUILD_TYPE": "Release" } },
+		{ "name": "debug"  , "hidden": true, "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug"   } },
+		{
+			"name": "raspberry_pi", "hidden": true, "inherits": "common",
+			"cacheVariables": { "ENABLE_GPIO": "ON" }
+		},
+		{
+			"name": "raspberry_pi-release", "inherits": ["raspberry_pi", "release"],
+			"displayName": "Raspberry Pi | Release"
+		},
+		{
+			"name": "raspberry_pi-debug", "inherits": ["raspberry_pi", "debug"],
+			"displayName": "Raspberry Pi | Debug"
+		},
+		{
+			"name": "linux-no_gpio", "hidden": true, "inherits": "common",
+			"cacheVariables": { "ENABLE_GPIO": "OFF" }
+		},
+		{
+			"name": "linux-no_gpio-release", "inherits": ["linux-no_gpio", "release"],
+			"displayName": "Linux with No GPIO | Release"
+		},
+		{
+			"name": "linux-no_gpio-debug", "inherits": ["linux-no_gpio", "debug"],
+			"displayName": "Linux with No GPIO | Debug",
+			"cacheVariables": { "ENABLE_GPIO": "OFF" }
+		}
+	],
+	"buildPresets": []
+}

--- a/sandman/source/CMakeLists.txt
+++ b/sandman/source/CMakeLists.txt
@@ -1,7 +1,7 @@
 include(GNUInstallDirs)
 
 set(SOURCE_FILES command.cpp config.cpp control.cpp gpio.cpp input.cpp logger.cpp mqtt.cpp 
-    notification.cpp reports.cpp routines.cpp shell.cpp timer.cpp)
+	notification.cpp reports.cpp routines.cpp shell.cpp timer.cpp)
 add_library(sandman_lib STATIC ${SOURCE_FILES})
 add_executable(sandman main.cpp)
 
@@ -11,7 +11,7 @@ target_compile_features(sandman_compiler_flags INTERFACE cxx_std_17)
 option(ENABLE_GPIO "Whether to use Raspberry Pi GPIO or not." ON)
 message(STATUS "ENABLE_GPIO = ${ENABLE_GPIO}")
 if (ENABLE_GPIO)
-    target_compile_definitions(sandman_lib PUBLIC ENABLE_GPIO)
+	target_compile_definitions(sandman_lib PUBLIC ENABLE_GPIO)
 endif()
 
 #target_compile_definitions(sandman_lib 
@@ -24,40 +24,40 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(Mosquitto IMPORTED_TARGET libmosquitto REQUIRED)
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-   target_compile_options(sandman_lib PUBLIC
+	target_compile_options(sandman_lib PUBLIC
 		$<$<CONFIG:Debug>:-fsanitize=address,undefined>
-      -Wall                    # Enable most common warnings
-      -Wextra                  # Enable additional warnings
+		-Wall                    # Enable most common warnings
+		-Wextra                  # Enable additional warnings
 		$<$<CONFIG:Debug>:-Werror> # In debug mode, treat warnings as errors.
-      -Wpedantic               # Enforce strict ISO C++ compliance
-      -Wshadow                 # Warn when a variable shadows another
-      -Wnon-virtual-dtor       # Warn if a class with virtual functions has a non-virtual destructor
-      -Wold-style-cast         # Warn about old-style casts
-      -Woverloaded-virtual     # Warn if a virtual function is overloaded
-      # -Wsign-conversion        # Warn on implicit conversions that change sign
+		-Wpedantic               # Enforce strict ISO C++ compliance
+		-Wshadow                 # Warn when a variable shadows another
+		-Wnon-virtual-dtor       # Warn if a class with virtual functions has a non-virtual destructor
+		-Wold-style-cast         # Warn about old-style casts
+		-Woverloaded-virtual     # Warn if a virtual function is overloaded
+		# -Wsign-conversion        # Warn on implicit conversions that change sign
 		-Wdiv-by-zero            # Warn on divide by zero.
-      -Wformat=2               # Warn about format string issues
-      -Wfloat-equal            # Warn if floating-point values are compared for equality
+		-Wformat=2               # Warn about format string issues
+		-Wfloat-equal            # Warn if floating-point values are compared for equality
 		-Wimplicit-fallthrough   # Warn if switch case fallthrough not marked with `[[fallthrough]]`
 		-Wdeprecated-declarations # Warn on usage of constructs that are declared with `[[deprecated]]`.
 		-Wno-error=deprecated-declarations
-   )
+	)
 
 	target_link_options(sandman_lib PUBLIC
 		$<$<CONFIG:Debug>:-fsanitize=address,undefined>
 	)
 
 else()
-   message(WARNING "Not using GNU compiler or Clang compiler.")
+	message(WARNING "Not using GNU compiler or Clang compiler.")
 endif()
 
 target_include_directories(sandman_lib PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 #target_include_directories(sandman_lib PUBLIC "${CMAKE_CURRENT_BINARY_DIR}")
 
-target_link_libraries(sandman_lib PUBLIC sandman_compiler_flags ${CURSES_LIBRARIES} 
-                      PkgConfig::Mosquitto)
+target_link_libraries(sandman_lib PUBLIC sandman_compiler_flags ${CURSES_LIBRARIES}
+							 PkgConfig::Mosquitto)
 if (ENABLE_GPIO)
-    target_link_libraries(sandman_lib PUBLIC gpiod)
+	target_link_libraries(sandman_lib PUBLIC gpiod)
 endif()
 
 target_link_libraries(sandman PUBLIC sandman_compiler_flags sandman_lib ${CURSES_LIBRARIES})

--- a/sandman/source/CMakeLists.txt
+++ b/sandman/source/CMakeLists.txt
@@ -25,6 +25,7 @@ pkg_check_modules(Mosquitto IMPORTED_TARGET libmosquitto REQUIRED)
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
    target_compile_options(sandman_lib PUBLIC
+		$<$<CONFIG:Debug>:-fsanitize=address,undefined>
       -Wall                    # Enable most common warnings
       -Wextra                  # Enable additional warnings
       -Werror                  # Treat warnings as errors
@@ -39,7 +40,9 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
 		-Wimplicit-fallthrough   # Warn if switch case fallthrough not marked with `[[fallthrough]]`
    )
 
-   # `-Wformat=2` would warn about non literal format strings.
+	target_link_options(sandman_lib PUBLIC
+		$<$<CONFIG:Debug>:-fsanitize=address,undefined>
+	)
 
 else()
    message(WARNING "Not using GNU compiler or Clang compiler.")

--- a/sandman/source/CMakeLists.txt
+++ b/sandman/source/CMakeLists.txt
@@ -1,8 +1,9 @@
 include(GNUInstallDirs)
 
-set(SOURCE_FILES command.cpp config.cpp control.cpp gpio.cpp input.cpp logger.cpp mqtt.cpp 
+set(SANDMAN_LIB_SOURCE_FILES command.cpp config.cpp control.cpp gpio.cpp input.cpp logger.cpp mqtt.cpp 
 	notification.cpp reports.cpp routines.cpp shell.cpp timer.cpp)
-add_library(sandman_lib STATIC ${SOURCE_FILES})
+add_library(sandman_lib STATIC ${SANDMAN_LIB_SOURCE_FILES})
+
 add_executable(sandman main.cpp)
 
 add_library(sandman_compiler_flags INTERFACE)

--- a/sandman/source/CMakeLists.txt
+++ b/sandman/source/CMakeLists.txt
@@ -28,7 +28,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
 		$<$<CONFIG:Debug>:-fsanitize=address,undefined>
       -Wall                    # Enable most common warnings
       -Wextra                  # Enable additional warnings
-      -Werror                  # Treat warnings as errors
+		$<$<CONFIG:Debug>:-Werror> # In debug mode, treat warnings as errors.
       -Wpedantic               # Enforce strict ISO C++ compliance
       -Wshadow                 # Warn when a variable shadows another
       -Wnon-virtual-dtor       # Warn if a class with virtual functions has a non-virtual destructor

--- a/sandman/source/CMakeLists.txt
+++ b/sandman/source/CMakeLists.txt
@@ -1,7 +1,7 @@
 include(GNUInstallDirs)
 
-set(SANDMAN_LIB_SOURCE_FILES command.cpp config.cpp control.cpp gpio.cpp input.cpp logger.cpp mqtt.cpp 
-	notification.cpp reports.cpp routines.cpp shell.cpp timer.cpp)
+set(SANDMAN_LIB_SOURCE_FILES command.cpp config.cpp control.cpp gpio.cpp input.cpp logger.cpp
+	mqtt.cpp notification.cpp reports.cpp routines.cpp shell.cpp timer.cpp)
 add_library(sandman_lib STATIC ${SANDMAN_LIB_SOURCE_FILES})
 
 add_executable(sandman main.cpp)

--- a/sandman/source/CMakeLists.txt
+++ b/sandman/source/CMakeLists.txt
@@ -50,6 +50,7 @@ target_include_directories(sandman_lib PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 
 target_link_libraries(sandman_lib PUBLIC sandman_compiler_flags ${CURSES_LIBRARIES}
 							 PkgConfig::Mosquitto)
+
 if (ENABLE_GPIO)
 	target_link_libraries(sandman_lib PUBLIC gpiod)
 endif()

--- a/sandman/source/CMakeLists.txt
+++ b/sandman/source/CMakeLists.txt
@@ -14,11 +14,6 @@ if (ENABLE_GPIO)
 	target_compile_definitions(sandman_lib PUBLIC ENABLE_GPIO)
 endif()
 
-#target_compile_definitions(sandman_lib 
-#                           PUBLIC SANDMAN_CONFIG_DIR="${CMAKE_INSTALL_FULL_SYSCONFDIR}/sandman/")
-
-#configure_file(sandman_config.h.in sandman_config.h)
-
 find_package(Curses REQUIRED)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(Mosquitto IMPORTED_TARGET libmosquitto REQUIRED)
@@ -52,7 +47,6 @@ else()
 endif()
 
 target_include_directories(sandman_lib PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
-#target_include_directories(sandman_lib PUBLIC "${CMAKE_CURRENT_BINARY_DIR}")
 
 target_link_libraries(sandman_lib PUBLIC sandman_compiler_flags ${CURSES_LIBRARIES}
 							 PkgConfig::Mosquitto)

--- a/sandman/source/CMakeLists.txt
+++ b/sandman/source/CMakeLists.txt
@@ -24,7 +24,7 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(Mosquitto IMPORTED_TARGET libmosquitto REQUIRED)
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-   target_compile_options(sandman_lib PUBLIC 
+   target_compile_options(sandman_lib PUBLIC
       -Wall                    # Enable most common warnings
       -Wextra                  # Enable additional warnings
       -Werror                  # Treat warnings as errors

--- a/sandman/source/CMakeLists.txt
+++ b/sandman/source/CMakeLists.txt
@@ -38,6 +38,8 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
       -Wformat=1               # Warn about format string issues
       -Wfloat-equal            # Warn if floating-point values are compared for equality
 		-Wimplicit-fallthrough   # Warn if switch case fallthrough not marked with `[[fallthrough]]`
+		-Wdeprecated-declarations # Warn on usage of constructs that are declared with `[[deprecated]]`.
+		-Wno-error=deprecated-declarations
    )
 
 	target_link_options(sandman_lib PUBLIC

--- a/sandman/source/CMakeLists.txt
+++ b/sandman/source/CMakeLists.txt
@@ -34,8 +34,9 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
       -Wnon-virtual-dtor       # Warn if a class with virtual functions has a non-virtual destructor
       -Wold-style-cast         # Warn about old-style casts
       -Woverloaded-virtual     # Warn if a virtual function is overloaded
-      # -Wsign-conversion      # Warn on implicit conversions that change sign
-      -Wformat=1               # Warn about format string issues
+      # -Wsign-conversion        # Warn on implicit conversions that change sign
+		-Wdiv-by-zero            # Warn on divide by zero.
+      -Wformat=2               # Warn about format string issues
       -Wfloat-equal            # Warn if floating-point values are compared for equality
 		-Wimplicit-fallthrough   # Warn if switch case fallthrough not marked with `[[fallthrough]]`
 		-Wdeprecated-declarations # Warn on usage of constructs that are declared with `[[deprecated]]`.

--- a/sandman/source/CMakeLists.txt
+++ b/sandman/source/CMakeLists.txt
@@ -21,21 +21,25 @@ pkg_check_modules(Mosquitto IMPORTED_TARGET libmosquitto REQUIRED)
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
 	target_compile_options(sandman_lib PUBLIC
+		# Use sanitizers in debug build.
 		$<$<CONFIG:Debug>:-fsanitize=address,undefined>
-		-Wall                    # Enable most common warnings
-		-Wextra                  # Enable additional warnings
-		$<$<CONFIG:Debug>:-Werror> # In debug mode, treat warnings as errors.
-		-Wpedantic               # Enforce strict ISO C++ compliance
-		-Wshadow                 # Warn when a variable shadows another
-		-Wnon-virtual-dtor       # Warn if a class with virtual functions has a non-virtual destructor
-		-Wold-style-cast         # Warn about old-style casts
-		-Woverloaded-virtual     # Warn if a virtual function is overloaded
-		# -Wsign-conversion        # Warn on implicit conversions that change sign
-		-Wdiv-by-zero            # Warn on divide by zero.
-		-Wformat=2               # Warn about format string issues
-		-Wfloat-equal            # Warn if floating-point values are compared for equality
-		-Wimplicit-fallthrough   # Warn if switch case fallthrough not marked with `[[fallthrough]]`
-		-Wdeprecated-declarations # Warn on usage of constructs that are declared with `[[deprecated]]`.
+
+		-Wall                      # Enable most common warnings.
+		-Wextra                    # Enable additional warnings.
+		$<$<CONFIG:Debug>:-Werror> # In debug build, treat warnings as errors.
+		-Wpedantic                 # Enforce strict ISO C++ compliance.
+		-Wshadow                   # Warn when a variable shadows another.
+		-Wnon-virtual-dtor         # Warn if class with virtual functions has non-virtual destructor.
+		-Wold-style-cast           # Warn about old-style casts (from C).
+		-Woverloaded-virtual       # Warn if a virtual function is overloaded.
+		# -Wsign-conversion        # Warn on implicit conversions that change sign.
+		-Wdiv-by-zero              # Warn on divide by zero.
+		-Wformat=2                 # Warn about format string issues.
+		-Wfloat-equal              # Warn if floating-point values are compared for equality.
+		-Wimplicit-fallthrough     # Warn if a switch case fallthrough is missing `[[fallthrough]]`.
+		-Wdeprecated-declarations  # Warn on usage of constructs marked with `[[deprecated]]`.
+
+		# Don't treat usage of constructs marked with `[[deprecated]]` as errors.
 		-Wno-error=deprecated-declarations
 	)
 

--- a/sandman/source/common/time_util.h
+++ b/sandman/source/common/time_util.h
@@ -9,7 +9,7 @@ namespace Common
 	/// @return Pointer to a static internal `std::tm` object on success, or null pointer otherwise.
 	/// The structure may be shared between `std::gmtime`, `std::localtime`, and `std::ctime`, and
 	/// may be overwritten on each invocation.
-	[[nodiscard]] inline std::tm* GetLocalTime()
+	[[nodiscard]] inline std::tm const* GetLocalTime()
 	{
 		auto const timePoint(std::chrono::system_clock::now());
 

--- a/sandman/source/gpio.cpp
+++ b/sandman/source/gpio.cpp
@@ -38,7 +38,7 @@ static constexpr int kPinOffValue = 1;
 //
 // enableGPIO: Whether to turn on GPIO or not.
 //
-void GPIOInitialize(bool const enableGPIO)
+void GPIOInitialize([[maybe_unused]] bool const enableGPIO)
 {
 	#if defined ENABLE_GPIO
 	

--- a/sandman/source/main.cpp
+++ b/sandman/source/main.cpp
@@ -491,7 +491,7 @@ static void SendMessageToDaemon(char const* message)
 //
 // Returns:	True if the program should exit, false if it should continue.
 //
-static bool HandleCommandLine(char** arguments, unsigned int argumentCount)
+static bool HandleCommandLine(char const* const* const arguments, unsigned int const argumentCount)
 {
 	for (unsigned int argumentIndex = 0; argumentIndex < argumentCount; argumentIndex++)
 	{
@@ -558,7 +558,7 @@ static bool HandleCommandLine(char** arguments, unsigned int argumentCount)
 	return false;
 }
 
-int main(int argc, char** argv)
+int main(int const argc, char const* const* const argv)
 {
 	// Deal with command line arguments.
 	if (HandleCommandLine(argv, argc) == true)


### PR DESCRIPTION
## CMake Presets
`CMakePresets.json` was added to streamline using different CMake configurations.
* Raspberry Pi | Release
* Raspberry Pi | Debug
* Linux with No GPIO | Release
* Linux with No GPIO | Debug

The "Raspberry Pi" configuration presets have access to the general-purpose input & output pins (GPIO pins). The "Linux with No GPIO" configuration presets don't have access to GPIO pins.

## Compilation Flags
Address sanitizer and undefined behavior sanitizer were added to the debug build. This increases the build time.

`-Werror` was removed from the release build but is still used in the debug build. `-Werror` is useful during development to enforce best practices by treating warnings as errors. However, different compilers and compiler versions may enable different warnings with `-Wall`, which could lead to issues if `-Werror` is set. For example, a program might fail to compile with a different compiler version due to newly introduced or modified warnings. Therefore, `-Werror` is omitted in the release build to ensure that end-users can successfully compile the program, even if a warning is raised during the compilation process.
